### PR TITLE
Timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ data_processing/combine_data.py
 
 data_processing/rov_sim.py
 - Use to visualize the sensor readouts in space with video (when captured)
+- Example command line:
+`python rov_sim.py --data_file ../data/test_data/csv_and_navest.csv --video_dir /Volumes/LaCie/video --mesh_file ../data/ring_depth.csv`
 
 data_processing/visualize_mass_spec.py
 - Use to look at the mass spectrometry density at a given time. 

--- a/README.md
+++ b/README.md
@@ -22,4 +22,7 @@ data_processing/combine_data.py
 data_processing/rov_sim.py
 - Use to visualize the sensor readouts in space with video (when captured)
 
-    
+data_processing/visualize_mass_spec.py
+- Use to look at the mass spectrometry density at a given time. 
+- Also contains tools for extracting the cleaned up wide and long transformations
+- The script itself will output a matplotlib plot of the readout closest to the given time.

--- a/data_processing/rov_sim.py
+++ b/data_processing/rov_sim.py
@@ -22,6 +22,10 @@ import utils
 
 
 def get_frames(video_dir):
+    """
+    Given a directory of videos,
+    this function will calculate the unix start and end time 
+    of each, and return a map from filename to the start and end times."""
 
     start_end_by_file = {}
 
@@ -61,6 +65,10 @@ def time_to_file(time, start_end_by_file, return_int=False):
 
 
 class CaptureHolder():
+    """
+    This class is designed to aid in retrieving frames from a directory of videos 
+    without opening and closing files more than necessary.
+    """
     def __init__(self, video_dir):
         self.cap = None
         self.file = None
@@ -117,9 +125,7 @@ def run_server(fig, timeline, near_vent, start_end_by_file, cap):
             'overflowX': 'scroll',
             'overflowY': 'scroll',
             "height": "450px",
-    #         "margin": "auto",
             "margin-top": "15px",
-    #         'height': '450px'
         },
         'display_wrapper': {
             'display': 'flex',
@@ -151,12 +157,11 @@ def run_server(fig, timeline, near_vent, start_end_by_file, cap):
         
 
         
-    ], style={})#'display':'flex', 'flex-direction':'row'})
+    ], style={})
         
     # SCRIPTING
     @app.callback(
         Output(component_id = 'camera', component_property='figure'),
-        # Input('spatial', 'clickData')
         Input('timeline', 'clickData')
     )
     def set_camera(node_clicked):
@@ -167,13 +172,8 @@ def run_server(fig, timeline, near_vent, start_end_by_file, cap):
         return cap.get_image(data.iloc[custom_data]['video_file'], seek_dist)
         
         
-    #     return px.imshow(im_by_time[timestamp])
-    #     return px.imshow(video_extraction.decompress_image(im_by_time[timestamp]))
-
-
     @app.callback(
         Output(component_id = 'frame_selector', component_property='value'),
-        # Input('spatial', 'clickData')
         Input('timeline', 'clickData')
     )
     def set_frame(node_clicked):
@@ -184,7 +184,6 @@ def run_server(fig, timeline, near_vent, start_end_by_file, cap):
 
     @app.callback(
         Output(component_id = 'sensor_display', component_property='children'),
-        # Input('spatial', 'clickData')
         Input('timeline', 'clickData')
     )
     def set_sensor_readout(node_clicked):
@@ -199,6 +198,15 @@ def run_server(fig, timeline, near_vent, start_end_by_file, cap):
 
 
 def get_args():
+    """
+    Parsing for commandline args. 
+
+    Example command (may change depending on repository structure): 
+        python rov_sim.py --data_file ../data/test_data/csv_and_navest.csv \
+            --video_dir /Volumes/LaCie/video \
+            --mesh_file ../data/ring_depth.csv
+    
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--data_file", 
@@ -275,13 +283,5 @@ if __name__ == '__main__':
         customdata=near_vent.index
     )
     timeline = go.Figure(data = [timeline_plot])
-
-    # timeline = px.scatter(
-    #     near_vent, 
-    #     x="unix_time", 
-    #     y = [0]*len(near_vent), 
-    #     color = "rgb",
-    #     color_discrete_map="identity"
-    # )
 
     run_server(fig, timeline, near_vent, start_end_by_file, cap)

--- a/data_processing/rov_sim.py
+++ b/data_processing/rov_sim.py
@@ -104,11 +104,9 @@ class CaptureHolder():
 
 
 
-def run_server(fig, near_vent, start_end_by_file, cap):
+def run_server(fig, timeline, near_vent, start_end_by_file, cap):
 
     columns_of_interest = near_vent.columns
-        
-        
 
     app = Dash(__name__)
 
@@ -144,13 +142,12 @@ def run_server(fig, near_vent, start_end_by_file, cap):
         
         html.Div(children = [
             dcc.Graph(id = 'spatial', figure=fig),
-            html.Div(children = [
-                'Unix Time: ',
-                dcc.Input(value=0, id='frame_selector', style={'margin': 'auto'}), 
-
-            ])
-
-        ], )
+            dcc.Graph(id='timeline', figure=timeline)
+        ], style = styles['display_wrapper']),
+        html.Div(children = [
+            'Unix Time: ',
+            dcc.Input(value=0, id='frame_selector', style={'margin': 'auto'}), 
+        ]),
         
 
         
@@ -159,7 +156,8 @@ def run_server(fig, near_vent, start_end_by_file, cap):
     # SCRIPTING
     @app.callback(
         Output(component_id = 'camera', component_property='figure'),
-        Input('spatial', 'clickData')
+        # Input('spatial', 'clickData')
+        Input('timeline', 'clickData')
     )
     def set_camera(node_clicked):
         custom_data = node_clicked['points'][0]['customdata']
@@ -175,7 +173,8 @@ def run_server(fig, near_vent, start_end_by_file, cap):
 
     @app.callback(
         Output(component_id = 'frame_selector', component_property='value'),
-        Input('spatial', 'clickData')
+        # Input('spatial', 'clickData')
+        Input('timeline', 'clickData')
     )
     def set_frame(node_clicked):
         print(node_clicked)
@@ -185,7 +184,8 @@ def run_server(fig, near_vent, start_end_by_file, cap):
 
     @app.callback(
         Output(component_id = 'sensor_display', component_property='children'),
-        Input('spatial', 'clickData')
+        # Input('spatial', 'clickData')
+        Input('timeline', 'clickData')
     )
     def set_sensor_readout(node_clicked):
         node_index = node_clicked['points'][0]['customdata']
@@ -264,4 +264,24 @@ if __name__ == '__main__':
     PLOT_MESH = True
     fig = go.Figure(data = ([mesh, scatterplot] if PLOT_MESH else [scatterplot]))
 
-    run_server(fig, near_vent, start_end_by_file, cap)
+    timeline_plot = go.Scatter(
+        x=near_vent.unix_time,
+        y=[0]*len(near_vent),
+        text = near_vent.unix_time,
+        mode="markers",
+        marker=dict(
+            color=near_vent.rgb,
+        ),
+        customdata=near_vent.index
+    )
+    timeline = go.Figure(data = [timeline_plot])
+
+    # timeline = px.scatter(
+    #     near_vent, 
+    #     x="unix_time", 
+    #     y = [0]*len(near_vent), 
+    #     color = "rgb",
+    #     color_discrete_map="identity"
+    # )
+
+    run_server(fig, timeline, near_vent, start_end_by_file, cap)

--- a/data_processing/visualize_mass_spec.py
+++ b/data_processing/visualize_mass_spec.py
@@ -1,0 +1,80 @@
+import utils
+import os
+import argparse
+import pandas as pd
+import matplotlib.pyplot as plt
+import plotly.express as px
+
+
+
+
+def get_long_data(data_dir):
+    files = os.listdir(data_dir)
+    files.sort()
+
+    split_data = [pd.read_csv(os.path.join(data_dir, filename)) for filename in files]
+
+
+    long_split = []
+    for data in split_data:
+        data = data.melt(id_vars=data.columns[0], var_name='time', value_name='mass_spec')
+        data['mass'] = data[data.columns[0]]
+        data = data.drop(columns=data.columns[0])
+        long_split.append(data)
+
+    long_data = pd.concat(long_split, ignore_index=True)
+
+
+    long_data['time'] = long_data['time'].astype('float64')
+    return long_data
+
+def get_wide_data(data_dir):
+    files = os.listdir(data_dir)
+    files.sort()
+
+    split_data = [pd.read_csv(os.path.join(data_dir, filename), header=None) for filename in files]
+    # The headers are stored as the first column of every file
+    # With a placeholder 0.0 at the top. So we are taking 
+    # Everything but the 0 in the first column of the first file
+    header = ['time'] + split_data[0][0][1:].tolist()
+
+    transposed_data = []
+    for data in split_data:
+        data = data.drop(columns=[0])
+        data = data.transpose()
+        data.columns = header
+        transposed_data.append(data)
+
+    combined = pd.concat(transposed_data, ignore_index=True)
+    return combined
+
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--data_dir', 
+        type=str, 
+        required=True, 
+        help="A directory of mass_spec CSVs with the first column storing mass, and headers representing time"
+    )
+
+    parser.add_argument(
+        '--time',
+        type=float,
+        required=True,
+        help="Will show a cutout of mass spec at closest point to given time."
+    )
+    
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = get_args()
+    wide_data = get_wide_data(args.data_dir)
+
+    utils.get_row_by_value(wide_data, 'time', args.time)[1:].plot()
+    plt.show()
+
+


### PR DESCRIPTION
To improve usability, this branch removes ability to click on the spatial plots to pull up data on the "rov_sim.py," however it adds the ability to pull up data using a simple timeline. This immediately adds more control on the timepoint accessed, (however removes some ease of control over the physical origin of the data we are looking at). 

Overall I think this change makes the tool more usable.